### PR TITLE
Rename belongTo to belongsTo

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -50,7 +50,7 @@
     return attrs;
   };
 
-  Model.prototype.belongTo = function(name, factoryName, ref) {
+  Model.prototype.belongsTo = function(name, factoryName, ref) {
     return setAssociation(this, name, factoryName, ref, true);
   };
 


### PR DESCRIPTION
`hasMany` and `hasOne` are both 3rd person singular whereas `belongTo`
is not 3rd person. The original wording is `belongsTo`, so `belongTo`
leads to confusion.
