### PR TITLE
Corrected a bug with property checking and added deep merging.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -8,7 +8,9 @@
 
     for(var prop in source) {
       if (source.hasOwnProperty(prop)) {
-        if (!target[prop] || !keep) {
+        if (typeof(target[prop]) === 'object' && typeof(source[prop]) === 'object') {
+          libAPI.utils.merge(target[prop], source[prop], keep);
+        } else if (!target.hasOwnProperty(prop) || !keep) {
           target[prop] = source[prop];
         }
       }

--- a/test/unit/UtilsSpec.js
+++ b/test/unit/UtilsSpec.js
@@ -31,6 +31,34 @@ describe('Utils', function () {
 				libAPI.utils.merge(target, source);
 				expect(target).to.eql({mocha:false, jasmine: false, qunit: true});
 			});
+
+			describe('with embedded objects', function () {
+				var targetEmbedded, sourceEmbedded;
+
+				beforeEach(function () {
+					targetEmbedded = {foo: false, bar: true};
+					target.embedded = targetEmbedded;
+					sourceEmbedded = {foo: true, rab: false};
+				});
+
+				it('no changing when embedded source empty', function () {
+					var origin = targetEmbedded;
+					libAPI.utils.merge(target, source);
+					expect(target.embedded).to.eql(origin);
+				});
+
+				it('with keep', function () {
+					source.embedded = sourceEmbedded;
+					libAPI.utils.merge(target, source, true);
+					expect(target.embedded).to.eql({foo: false, bar: true, rab: false});
+				});
+
+				it('without keep', function () {
+					source.embedded = sourceEmbedded;
+					libAPI.utils.merge(target, source);
+					expect(target.embedded).to.eql({foo: true, bar: true, rab: false});
+				});
+			});
 		});
 	});
 });


### PR DESCRIPTION
I fixed a bug with the merging of boolean properties in the following line:

```
if (!target[prop] || !keep) {
```

In the event that `target[prop]` was a false value, this was still merging the property values.  I found this bug while testing changes for the ability to deep merge models.  This will allow for the definition of objects in the following fashion:

```
FactoryGirl.define('parent', function() {
    this.foo = true;
    this.bar = {
        oof: false,
        rab: true
    };
});

FactoryGirl.define('child', {inherit: 'parent'}, function() {
    this.bar = {
        oof: true,
        foo: false
    };
});
```

Whereby the end result would produce an object with a value of `bar` equal to `{oof: true, rab: true, foo: false}`.
