### PR TITLE
Added check to maintain definitions after subsequent imports.

### DIFF
--- a/src/module.prefix
+++ b/src/module.prefix
@@ -4,4 +4,7 @@
  * License: MIT
  */
 
-(function(FactoryGirl, libAPI, global) {
+if (typeof FactoryGirl === 'undefined') {
+  FactoryGirl = 'undefined' !== typeof module && module.exports || {};
+
+  (function(FactoryGirl, libAPI, global) {

--- a/src/module.suffix
+++ b/src/module.suffix
@@ -1,1 +1,2 @@
-})(FactoryGirl = (('undefined' !== typeof module && module.exports) ? module.exports : {}), {}, this);
+  })(FactoryGirl, {}, this);
+}


### PR DESCRIPTION
We are using FactoryGirl on a project involving polymer.js and are defining factories in different components.  For any component where we import two or more factories, the last import was the only set of definitions that "took".

Given that two components (i.e., `xh-data-events` and `xh-api-device`) both import factory_girl.js, if you have the following snippet of code:

```
    <link rel="import" href="../../xh-data-events/tests/factories/index.html">
    <link rel="import" href="../../xh-api-device/tests/factories/index.html">
```

The second import will cause another import of factory_girl.js.  This would in-turn cause the re-initialization of the `FactoryGirl` global module and the loss of any definitions that were made as part of `xh-data-events`.

Adding a simple check to the compilation template files remedies this problem.  Additionally, the use of the lazy logic initializers (i.e., `foo && bar || rab`) will ensure that FactoryGirl is initialized at this level no matter what.
